### PR TITLE
Switch from JSX.Element to React.ReactElement as is now required by React 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The app interaction is intended to be minimally intrusive in the app codebase.
 
 The app interacts primarily by registering elements as "help targets", and calling a callback to indicate that the target has been used.
 ```js
-function AppWithHelp(): JSX.Element {
+function AppWithHelp(): React.ReactElement {
    return (
        <DynamicHelp.HelpProvider>
            <App />
@@ -26,7 +26,7 @@ function AppWithHelp(): JSX.Element {
    );
 }
 
-export const AComponent = (props: ConfigProps): JSX.Element => {
+export const AComponent = (props: ConfigProps): React.ReactElement => {
 
    const { registerTargetItem } = React.useContext(DynamicHelp.Api);
 
@@ -50,7 +50,7 @@ export const AComponent = (props: ConfigProps): JSX.Element => {
 Help Items and their Flows are specified in a separate JSX tree.
 
 ```js
-export function HelpFlows(): JSX.Element {
+export function HelpFlows(): React.ReactElement {
    return (
        <div className="help-flow-container">
            <HelpFlow id="new-user" showInitially={true}>

--- a/src/components/HelpController.tsx
+++ b/src/components/HelpController.tsx
@@ -44,7 +44,7 @@ import { SystemContextProvider, SystemContext, log } from "../DynamicHelp";
  * ... because the state gets saved, making it hard to repeat tests!
  */
 
-function FloatingStateReset(): JSX.Element {
+function FloatingStateReset(): React.ReactElement {
   const api = React.useContext(SystemContext).api;
 
   const resetHelp = () => {
@@ -78,7 +78,7 @@ type HelpControllerProps = {
   storage: DynamicHelpStorageAPI;
   storageReady: boolean;
   debug: boolean;
-  children: JSX.Element | JSX.Element[];
+  children: React.ReactElement | React.ReactElement[];
 };
 
 type HelpControllerState = {
@@ -477,7 +477,7 @@ export class HelpController extends React.Component<
     return this.props.dictionary[phrase];
   };
 
-  render(): JSX.Element {
+  render(): React.ReactElement {
     return (
       <>
         <SystemContextProvider

--- a/src/components/HelpFlow.tsx
+++ b/src/components/HelpFlow.tsx
@@ -30,7 +30,7 @@ type HelpFlowProps = {
     description?: string; // passed to the app if it asks "what flows are there?"
     showInitially?: boolean;
     debug?: boolean; // if this is turned on it sets debug on the children as well, _overriding_ their debug prop.
-    children: JSX.Element | JSX.Element[];
+    children: React.ReactElement | React.ReactElement[];
 };
 
 function defaultId(
@@ -56,7 +56,7 @@ export const HelpFlow = ({
     debug = false,
     description = "",
     ...props
-}: HelpFlowProps): JSX.Element => {
+}: HelpFlowProps): React.ReactElement => {
     const helpContext = React.useContext(SystemContext);
     const { api, systemState, storageReady } = helpContext;
 
@@ -97,7 +97,7 @@ export const HelpFlow = ({
     // It's also the place that "if the flow has debug then the Items do too" is implemented
 
     const children = React.useMemo(
-        () => React.Children.toArray(props.children) as JSX.Element[],
+        () => React.Children.toArray(props.children) as React.ReactElement[],
         [props.children],
     );
 

--- a/src/components/HelpItem.tsx
+++ b/src/components/HelpItem.tsx
@@ -68,7 +68,7 @@ export function HelpItem({
     debug = false,
     highlightTarget = true,
     ...props
-}: HelpItemProperties): JSX.Element {
+}: HelpItemProperties): React.ReactElement {
     const {
         appTargetsState,
         systemState,

--- a/src/components/HelpProvider.tsx
+++ b/src/components/HelpProvider.tsx
@@ -40,7 +40,7 @@ type HelpProviderProps = {
   storageApi?: DynamicHelpStorageAPI;
   storageReady?: boolean;
   debug?: boolean;
-  children: JSX.Element | JSX.Element[];
+  children: React.ReactElement | React.ReactElement[];
 };
 
 const DEFAULT_DICTIONARY: HelpPopupDictionary = {
@@ -68,7 +68,7 @@ export const HelpProvider = ({
   storageReady = true,
   debug = false,
   ...props
-}: HelpProviderProps): JSX.Element => {
+}: HelpProviderProps): React.ReactElement => {
   const [app, ...helpFlows] = React.Children.toArray(
     props.children,
   ) as React.ReactElement[];


### PR DESCRIPTION
This is supported in React 18 too so it shouldn't break any existing apps.