### PR TITLE
Ugly type hacks to restore buildability

### DIFF
--- a/src/components/HelpFlow.tsx
+++ b/src/components/HelpFlow.tsx
@@ -102,13 +102,16 @@ export const HelpFlow = ({
     );
 
     const childrenWithIds = children.map((child, index) => {
-        const id =
-            child.props.id || defaultId(flowId, child.props.target, index);
+        const childProps = child.props as {
+            id?: string;
+            target: HelpTypes.TargetId;
+        };
+        const id = childProps.id || defaultId(flowId, childProps.target, index);
         return React.cloneElement(child, {
-            ...child.props,
+            ...childProps,
             myId: id,
             ...(debug ? { debug } : {}),
-        });
+        } as any);
     });
 
     log(debug, "HelpFlow render", flowId, "with storage ready:", storageReady);


### PR DESCRIPTION
Under the online-go.com build environment, which I think the notable differences are an updated typescript and updated react, we get some probably valid type errors in this section of code stemming I think from more thorough knowledge (or lack there of) of the underlying types of childrens. This might might only occur with the JSX.Element -> React.ReactElement update.

There is undoubtedly a better more thorough fix than what this PR contains, but to get things building again quickly this is a minimal change to make the compiler happy again without changing how anything else works in the system.